### PR TITLE
Update text to be aligned with our project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Bazel Central Registry Web UI
+# Eclipse S-CORE Bazel Registry Modules Web UI
 
-This repository provides a web UI for the [Bazel Central Registry (BCR)](https://github.com/eclipse-score/bazel_registry).
+This repository provides a web UI for the [Eclipse S‑CORE Bazel Modules Registry](https://github.com/eclipse-score/bazel_registry).
 It entirely consists of statically rendered pages, which are updated as soon as a new commit is pushed to the BCR.
 
 ## Contributing

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -4,13 +4,15 @@ interface FooterProps {}
 
 export const REPORT_LINK =
   'https://github.com/eclipse-score/bazel_registry/issues'
-export const BCR_UI_REPO_LINK = 'https://github.com/eclipse-score/bazel_registry_ui'
+export const BCR_UI_REPO_LINK =
+  'https://github.com/eclipse-score/bazel_registry_ui'
 
 export const Footer: React.FC<FooterProps> = () => {
   return (
     <footer className="flex flex-col items-center justify-center gap-2 h-18 mt-4 bottom-2">
       <div className="text-center">
-      The Eclipse S-Core Bazel Registry is maintained by the Eclipse S-Core team.
+        The Eclipse S-Core Bazel Registry is maintained by the Eclipse S-Core
+        team.
       </div>
       <div className="text-center">
         To report an issue with one of the modules, see the{' '}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,13 +1,13 @@
-import type { NextPage } from 'next'
-import Head from 'next/head'
-import { Header } from '../components/Header'
-import { Footer } from '../components/Footer'
-import React, { useState } from 'react'
-import { useRouter } from 'next/router'
-import { buildSearchIndex, SearchIndexEntry } from '../data/utils'
-import { ModuleCard } from '../components/ModuleCard'
-import { GetStaticProps } from 'next'
 import { parseISO } from 'date-fns'
+import type { NextPage } from 'next'
+import { GetStaticProps } from 'next'
+import Head from 'next/head'
+import { useRouter } from 'next/router'
+import React, { useState } from 'react'
+import { Footer } from '../components/Footer'
+import { Header } from '../components/Header'
+import { ModuleCard } from '../components/ModuleCard'
+import { buildSearchIndex, SearchIndexEntry } from '../data/utils'
 
 // TODO: fetch correct version during build
 // const HIGHLIGHTED_MODULES = [
@@ -59,7 +59,7 @@ const Home: NextPage<HomePageProps> = ({ searchIndex }) => {
   return (
     <div className="flex flex-col">
       <Head>
-        <title>Bazel Central Registry</title>
+        <title>Eclipse S‑CORE Bazel Modules Registry</title>
         <link rel="icon" href="/favicon.png" />
       </Head>
 
@@ -67,7 +67,7 @@ const Home: NextPage<HomePageProps> = ({ searchIndex }) => {
       <main className="m-4 l:m-0">
         <div className="max-w-4xl w-4xl mx-auto mt-8 flex flex-col items-center">
           <h1 className="text-bzl-green font-bold text-6xl">
-            Bazel Central Registry
+            Eclipse S‑CORE Bazel Modules Registry
           </h1>
           <form onSubmit={handleSubmitSearch} className="contents">
             <input

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -1,13 +1,13 @@
-import type { NextPage } from 'next'
-import Head from 'next/head'
-import { Header } from '../components/Header'
-import { Footer } from '../components/Footer'
-import React, { useEffect, useState } from 'react'
-import { useRouter } from 'next/router'
-import { GetStaticProps } from 'next'
-import { buildSearchIndex, SearchIndexEntry } from '../data/utils'
 import Fuse from 'fuse.js'
+import type { NextPage } from 'next'
+import { GetStaticProps } from 'next'
+import Head from 'next/head'
+import { useRouter } from 'next/router'
+import React, { useEffect, useState } from 'react'
+import { Footer } from '../components/Footer'
+import { Header } from '../components/Header'
 import { ModuleCard } from '../components/ModuleCard'
+import { buildSearchIndex, SearchIndexEntry } from '../data/utils'
 
 interface SearchPageProps {
   searchIndex: SearchIndexEntry[]
@@ -61,7 +61,7 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
   return (
     <div className="flex flex-col">
       <Head>
-        <title>Bazel Central Registry</title>
+        <title>Eclipse S‑CORE Bazel Modules Registry</title>
         <link rel="icon" href="/favicon.png" />
       </Head>
 


### PR DESCRIPTION
Change the UI main text to be Eclipse S‑CORE Bazel Modules Registry and update the documentation.

Also-by: Aymen Soussi aymen.soussi@expleogroup.com

Fixes https://github.com/eclipse-score/score/issues/850